### PR TITLE
Replace deprecated logger.warn usage

### DIFF
--- a/skivvy/matchers.py
+++ b/skivvy/matchers.py
@@ -222,7 +222,7 @@ def file_reader(expected, actual):
     is_match = str(data) == str(actual)
     error_msg = "Files content in %s didn't match - expected: %s but got %s" % (expected, data, actual)
     if not is_match:
-        _logger.warn(error_msg)
+        _logger.warning(error_msg)
     return is_match, error_msg
 
 


### PR DESCRIPTION
## Summary
- replace deprecated `logger.warn` with `logger.warning`

## Testing
- `pytest -q`
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68a5401c95f8832a9b39a4e3d503cdd1