### PR TITLE
Added option: file_order=<"natural" | "lexical">

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,12 +181,14 @@ You can override settings at runtime from either CLI flags or environment variab
 CLI:
 ```bash
 skivvy cfg.json --set log_level=DEBUG --set fail_fast=true
+skivvy cfg.json --set file_order=natural
 ```
 
 Environment variables use the `SKIVVY_` prefix with upper-cased keys:
 ```bash
 SKIVVY_LOG_LEVEL=DEBUG skivvy cfg.json
 SKIVVY_FAIL_FAST=true skivvy cfg.json
+SKIVVY_FILE_ORDER=natural skivvy cfg.json
 ```
 
 Precedence for settings is:
@@ -211,11 +213,14 @@ Or specifying all currently supported settings:
   "base_url": "https://api.example.com",
   "colorize": true,
   "fail_fast": false,
+  "file_order": "lexical",
   "brace_expansion": true,
   "validate_variable_names": true,
   "auto_coerce": true,
   "matchers": "./matchers"
 ```
+
+- `file_order` (default `lexical`) - controls deterministic test discovery/execution order. Use `natural` for human-friendly numeric ordering (e.g. `1, 2, 10` instead of `1, 10, 2`).
 
 ## Test file keys (most used)
 - `url` (string required), 
@@ -322,6 +327,7 @@ a skivvy testfile, can contain the following flags that changes how the tests is
 * *log_level* - a low value like 10, shows ALL logging, a value like 20 shows only info and more severe
 * *colorize* - terminal colors for diffs (default is true)
 * *fail_fast* - aborts the test run immediately when a testcase fails instead of running the whole suite (default is false) 
+* *file_order* - deterministic test file ordering, `lexical` (default) or `natural` (human-friendly numeric sort)
 * *matchers* - directory where you place your own matchers (eg "./matchers")
 
 #### mandatory settings for a testcase

--- a/src/skivvy/skivvy.py
+++ b/src/skivvy/skivvy.py
@@ -167,7 +167,11 @@ def run():
     base_conf = create_testcase(env_overrides, cfg_conf)
     suite_conf = create_testcase(cli_overrides, base_conf)
 
-    tests = file_util.list_files(suite_conf["tests"], suite_conf["ext"])
+    tests = file_util.list_files(
+        suite_conf["tests"],
+        suite_conf["ext"],
+        file_order=suite_conf["file_order"],
+    )
     log.info(f"{len(tests)} tests found.")
     custom_matchers.load(suite_conf)
     matchers.add_negating_matchers()

--- a/src/skivvy/skivvy_config2.py
+++ b/src/skivvy/skivvy_config2.py
@@ -74,6 +74,11 @@ class Settings:
     )
     COLORIZE = Option("colorize", True, "Enable colored output")
     FAIL_FAST = Option("fail_fast", False, "Stop on first failure")
+    FILE_ORDER = Option(
+        "file_order",
+        "lexical",
+        "Test file ordering: lexical (default) or natural",
+    )
     MATCHERS = Option("matchers", None, "Directory containing custom matcher files")
     MATCHER_OPTIONS = Option("matcher_options", {}, "Per-matcher configuration options")
 

--- a/tests/test_file_util.py
+++ b/tests/test_file_util.py
@@ -1,0 +1,48 @@
+from pathlib import Path
+
+import pytest
+
+from skivvy.util.file_util import list_files
+
+
+def _relative_paths(base: Path, files: list[str]) -> list[str]:
+    return [Path(f).relative_to(base).as_posix() for f in files]
+
+
+def test_list_files_uses_lexical_order_by_default(tmp_path):
+    tests_dir = tmp_path / "tests"
+    (tests_dir / "10_group").mkdir(parents=True)
+    (tests_dir / "2_group").mkdir(parents=True)
+    (tests_dir / "2_group" / "10_case.json").write_text("{}")
+    (tests_dir / "2_group" / "2_case.json").write_text("{}")
+    (tests_dir / "10_group" / "1_case.json").write_text("{}")
+
+    files = list_files(str(tests_dir), ".json")
+
+    assert _relative_paths(tmp_path, files) == [
+        "tests/10_group/1_case.json",
+        "tests/2_group/10_case.json",
+        "tests/2_group/2_case.json",
+    ]
+
+
+def test_list_files_supports_natural_order(tmp_path):
+    tests_dir = tmp_path / "tests"
+    (tests_dir / "10_group").mkdir(parents=True)
+    (tests_dir / "2_group").mkdir(parents=True)
+    (tests_dir / "2_group" / "10_case.json").write_text("{}")
+    (tests_dir / "2_group" / "2_case.json").write_text("{}")
+    (tests_dir / "10_group" / "1_case.json").write_text("{}")
+
+    files = list_files(str(tests_dir), ".json", file_order="natural")
+
+    assert _relative_paths(tmp_path, files) == [
+        "tests/2_group/2_case.json",
+        "tests/2_group/10_case.json",
+        "tests/10_group/1_case.json",
+    ]
+
+
+def test_list_files_rejects_unknown_file_order(tmp_path):
+    with pytest.raises(ValueError, match="Unknown file_order"):
+        list_files(str(tmp_path), ".json", file_order="weird")

--- a/tests/test_overrides.py
+++ b/tests/test_overrides.py
@@ -12,12 +12,14 @@ def test_parse_cli_overrides_coerces_values():
         [
             "log_level=DEBUG",
             "fail_fast=true",
+            "file_order=natural",
             'matcher_options={"$valid_url":{"replace":{"^//":"http://"}}}',
         ]
     )
 
     assert overrides["log_level"] == "DEBUG"
     assert overrides["fail_fast"] is True
+    assert overrides["file_order"] == "natural"
     assert overrides["matcher_options"]["$valid_url"]["replace"]["^//"] == "http://"
 
 
@@ -35,6 +37,7 @@ def test_parse_env_overrides_reads_known_keys():
     env = {
         "SKIVVY_LOG_LEVEL": "WARNING",
         "SKIVVY_FAIL_FAST": "TRUE",
+        "SKIVVY_FILE_ORDER": "natural",
         "SKIVVY_MATCHER_OPTIONS": '{"$contains":{"min_len":2}}',
         "SKIVVY_NOT_A_SETTING": "ignored",
     }
@@ -44,6 +47,7 @@ def test_parse_env_overrides_reads_known_keys():
     assert overrides == {
         "log_level": "WARNING",
         "fail_fast": True,
+        "file_order": "natural",
         "matcher_options": {"$contains": {"min_len": 2}},
     }
 


### PR DESCRIPTION
* Added option: file_order=<"natural" | "lexical"> (if not specified, "natural" is the default for backwards-compatibility)